### PR TITLE
🐛 fix(submenu icon) Fix highlight el-icon on active submenu

### DIFF
--- a/src/components/Navigation/MenuBar/MenuBarItem.vue
+++ b/src/components/Navigation/MenuBar/MenuBarItem.vue
@@ -110,7 +110,7 @@ export default {
   }
   /deep/ .el-submenu.submenu-active {
     & > .el-submenu__title,
-    .el-icon-location,
+    [class^="el-icon-"],
     .menu-font-awesome-icon {
       color: $--color-primary;
     }


### PR DESCRIPTION
修复二级菜单栏`el-icon-*` 无法高亮的问题